### PR TITLE
feat: link categories to gallery

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.16",
-    "daisyui": "^5.0.43"
+    "daisyui": "^5.0.43",
     "@testing-library/jest-dom": "^6.4.1",
     "@testing-library/react": "^16.1.0",
     "jsdom": "^24.0.0",

--- a/src/components/FeatureGrid.tsx
+++ b/src/components/FeatureGrid.tsx
@@ -14,13 +14,14 @@ const FeatureGrid = () => (
     <div className="container mx-auto px-4">
       <div className="grid gap-6 md:grid-cols-3">
         {features.map((f) => (
-          <div
+          <a
             key={f.title}
-            className="p-6 text-center rounded-lg shadow bg-base-100"
+            href={`/gallery?category=${encodeURIComponent(f.title)}`}
+            className="p-6 text-center rounded-lg shadow bg-base-100 block hover:shadow-lg"
           >
             <h3 className="mb-2 text-xl font-semibold">{f.title}</h3>
             <p className="text-sm opacity-80">{f.desc}</p>
-          </div>
+          </a>
         ))}
       </div>
     </div>

--- a/src/components/FilmRoll.tsx
+++ b/src/components/FilmRoll.tsx
@@ -4,8 +4,8 @@ import React from "react";
 /**
  * FilmRoll 膠卷底片元件
  */
-const FilmRoll: React.FC<{ images: ImageMetadata[] }> = (
-  { images }: { images: ImageMetadata[] },
+const FilmRoll: React.FC<{ images: ImageMetadata[]; category?: string }> = (
+  { images, category }: { images: ImageMetadata[]; category?: string },
 ) => {
   const [holeCount, setHoleCount] = React.useState(0);
   const ref = React.useRef(null);
@@ -32,6 +32,9 @@ const FilmRoll: React.FC<{ images: ImageMetadata[] }> = (
 
   return (
     <>
+      {category && (
+        <h2 className="text-center text-2xl my-4">{category}</h2>
+      )}
       <div
         ref={ref}
         className="

--- a/src/components/HeroWithOverlayImage.tsx
+++ b/src/components/HeroWithOverlayImage.tsx
@@ -5,11 +5,6 @@ import coverImage from "../assets/images/DSC_1587.jpg?url";
  * 首頁介紹畫面元件
  */
 const HeroWithOverlayImage = () => {
-  const handleClick = () => {
-    console.log("Button clicked!")
-    location.href = "/gallery";
-  }
-
   return (
     <div
       className="hero min-h-screen"
@@ -26,9 +21,6 @@ const HeroWithOverlayImage = () => {
           <p className="mb-5">
             歡迎來到我的個人攝影集。這裡記錄了我鏡頭下的世界。
           </p>
-          <button onClick={handleClick} className="btn btn-primary">
-            Get Started
-          </button>
         </div>
       </div>
     </div>

--- a/src/components/__tests__/FeatureGrid.test.tsx
+++ b/src/components/__tests__/FeatureGrid.test.tsx
@@ -1,10 +1,13 @@
 import { render, screen } from '@testing-library/react';
 import FeatureGrid from '../FeatureGrid';
 
-/** 確認功能區塊呈現三項特色 */
-test('renders all features', () => {
+/** 確認功能區塊呈現三項特色並可跳轉 */
+test('renders feature links', () => {
   render(<FeatureGrid />);
-  expect(screen.getByText('Landscape')).toBeInTheDocument();
-  expect(screen.getByText('Portraits')).toBeInTheDocument();
-  expect(screen.getByText('Urban')).toBeInTheDocument();
+  const landscape = screen.getByRole('link', { name: 'Landscape' });
+  expect(landscape).toHaveAttribute('href', '/gallery?category=Landscape');
+  const portraits = screen.getByRole('link', { name: 'Portraits' });
+  expect(portraits).toHaveAttribute('href', '/gallery?category=Portraits');
+  const urban = screen.getByRole('link', { name: 'Urban' });
+  expect(urban).toHaveAttribute('href', '/gallery?category=Urban');
 });

--- a/src/components/__tests__/FilmRoll.test.tsx
+++ b/src/components/__tests__/FilmRoll.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import FilmRoll from '../FilmRoll';
+
+// mock ResizeObserver for jsdom
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+(global as any).ResizeObserver = ResizeObserverMock;
+
+test('renders category heading', () => {
+  const mockImage = { src: 'test.jpg', width: 100, height: 100, format: 'jpg' } as any;
+  render(<FilmRoll images={[mockImage]} category="Landscape" />);
+  expect(screen.getByText('Landscape')).toBeInTheDocument();
+});

--- a/src/components/__tests__/HeroWithOverlayImage.test.tsx
+++ b/src/components/__tests__/HeroWithOverlayImage.test.tsx
@@ -1,9 +1,13 @@
 import { render, screen } from '@testing-library/react';
 import HeroWithOverlayImage from '../HeroWithOverlayImage';
 
-/** 確認首頁 Hero 區塊呈現標題與按鈕 */
-test('renders title and button', () => {
+/** 確認首頁 Hero 區塊呈現標題 */
+test('renders title without action button', () => {
   render(<HeroWithOverlayImage />);
-  expect(screen.getByRole('heading', { name: /vision portfolio/i })).toBeInTheDocument();
-  expect(screen.getByRole('button', { name: /get started/i })).toBeInTheDocument();
+  expect(
+    screen.getByRole('heading', { name: /vision portfolio/i })
+  ).toBeInTheDocument();
+  expect(
+    screen.queryByRole('button', { name: /get started/i })
+  ).toBeNull();
 });

--- a/src/pages/gallery.astro
+++ b/src/pages/gallery.astro
@@ -5,11 +5,14 @@ import coverImage from "../assets/images/DSC_1587.jpg";
 
 // Welcome to Astro! Wondering what to do next? Check out the Astro documentation at https://docs.astro.build
 // Don't want to use any of this? Delete everything in this file, the `assets`, `components`, and `layouts` directories, and start fresh.
+const { searchParams } = Astro.url;
+const category = searchParams.get('category') ?? '';
 ---
 
 <Layout>
   <FilmRoll
     client:only="react"
     images={[coverImage]}
+    category={category}
   />
 </Layout>


### PR DESCRIPTION
## Summary
- remove hero action button for cleaner landing page
- make feature cards link to gallery and pass category
- display passed category in gallery film roll

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ddd9d48c832782c77e129c269d7b